### PR TITLE
allow fallback-translations of non-existent keys

### DIFF
--- a/lib/exi18n.ex
+++ b/lib/exi18n.ex
@@ -85,8 +85,10 @@ defmodule ExI18n do
     if fallback(), do: get_translation(locale(), key), else: ""
   end
 
-  defp check_translation(nil, key), do: check_translation("", key)
-
+  defp check_translation(nil, key) do
+    if fallback(), do: get_translation(locale(), key), else: nil
+  end
+  
   defp check_translation(translation, _), do: translation
 
   defp check_values(translation, values) do


### PR DESCRIPTION
allow requests for keys which only exist in the fallback locale but not in the requested one